### PR TITLE
ch: Corrected link to Techrity Slack Workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ Congratulations!
 You've just submitted your project to the Techrity #Build4SocialGood Program! We cannot wait to see what you've made over the last couple of days!
 
 ## Questions?
-If you have questions or comments, please reach out to us on [Slack chat](https://bit.ly/build-for-social-slack)(#hackathon).
+If you have questions or comments, please reach out to us on [Slack chat](https://bit.ly/build-for-social-join-slack)(#hackathon).
 
 > This readme was redacted from the [ConsenSys - Road2Devcon Relay Repo](https://github.com/ConsenSys/Road-To-Devcon-Relay)


### PR DESCRIPTION
# What
- #Build4InformalSector Hackathon 2020

# Why
- Changed link to slack channel